### PR TITLE
Implement bytes::Buf and BufMut for CircBuf.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ keywords = ["buffer", "bytes", "circular", "ring"]
 
 [features]
 nightly = []
+bytes = ["bytes-rs"]
+
+[dependencies]
+bytes-rs = { version = "0.5", optional = true, package = "bytes" }
 
 [dev-dependencies]
 vecio = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ keywords = ["buffer", "bytes", "circular", "ring"]
 
 [features]
 nightly = []
-bytes = ["bytes-rs"]
+bytes = ["bytes_rs"]
 
 [dependencies]
-bytes-rs = { version = "0.5", optional = true, package = "bytes" }
+# Rename because a dependency can't have the same name as a feature.
+bytes_rs = { version = "0.5", optional = true, package = "bytes" }
 
 [dev-dependencies]
 vecio = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ manages a buffer of bytes allocated on the heap. The buffer can be grown when ne
 and can return slices into its internal buffer that can be used for both normal IO
 (`read` and `write`) as well as vector IO (`readv` and `writev`).
 
+## `bytes` support
+
+If the `bytes` feature flag is enabled, then the [bytes](https://github.com/tokio-rs/bytes)
+crate will be added as a dependency and the `Buf` and `BufMut` traits implemented for
+`CircBuf`. The optional vectored read/write functions are implemented, allowing you to use
+the `CircBuf` for efficient vectored IO operations with libraries such as `tokio`. See
+for example the [read_buf](https://docs.rs/tokio/0.2.21/tokio/io/trait.AsyncReadExt.html#method.read_buf)
+and [write_buf](https://docs.rs/tokio/0.2.21/tokio/io/trait.AsyncWriteExt.html#method.write_buf)
+methods, which can accept a `CircBuf` when the `bytes` feature flag is enabled.
+
 ## Example
 
 Below is a simple example of a server which makes use of a `CircBuf` to read messages

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,11 @@
 //! and can return slices into its internal buffer that can be used for both normal IO
 //! (e.g. `read` and `write`) as well as vector IO (`readv` and `writev`).
 //!
+//! ## Feature flags
+//!
+//! - `bytes`: Adds a dependency on the `bytes` crate and implements the `Buf` and `BufMut`
+//! traits from that crate.
+//!
 //! ## Example
 //!
 //! Below is a simple example of a server which makes use of a `CircBuf` to read messages
@@ -112,6 +117,9 @@
 
 #[cfg(feature = "nightly")]
 extern crate test;
+
+#[cfg(feature = "bytes")]
+extern crate bytes_rs;
 
 use std::boxed::Box;
 use std::error;
@@ -569,16 +577,16 @@ impl bytes_rs::Buf for CircBuf {
         }
     }
 
-    fn bytes_vectored<'a>(&'a self, dst: &mut [std::io::IoSlice<'a>]) -> usize {
+    fn bytes_vectored<'a>(&'a self, dst: &mut [io::IoSlice<'a>]) -> usize {
         let [left, right] = self.get_bytes();
         let mut count = 0;
         if let Some(slice) = dst.get_mut(0) {
             count += 1;
-            *slice = std::io::IoSlice::new(left);
+            *slice = io::IoSlice::new(left);
         }
         if let Some(slice) = dst.get_mut(1) {
             count += 1;
-            *slice = std::io::IoSlice::new(right);
+            *slice = io::IoSlice::new(right);
         }
         count
     }
@@ -949,6 +957,102 @@ mod tests {
         let mut s = String::new();
         assert_eq!(c.read_to_string(&mut s).unwrap(), 8);
         assert_eq!(s, "fizzbuzz");
+    }
+
+
+    #[cfg(feature = "bytes")]
+    #[test]
+    fn bytes_buf_and_bufmut() {
+        use bytes_rs::{Buf, BufMut};
+
+        let mut c = CircBuf::with_capacity(4).unwrap();
+
+        assert_eq!(c.remaining(), 0);
+        assert_eq!(c.remaining_mut(), 3);
+        unsafe { c.advance_mut(2); }
+        assert_eq!(c.remaining(), 2);
+        assert_eq!(c.remaining_mut(), 1);
+        c.advance(1);
+        assert_eq!(c.remaining(), 1);
+        assert_eq!(c.remaining_mut(), 2);
+        unsafe { c.advance_mut(1); }
+        assert_eq!(c.remaining(), 2);
+        assert_eq!(c.remaining_mut(), 1);
+
+        assert_eq!(<CircBuf as Buf>::bytes(&c).len(), 2);
+        assert_eq!(c.bytes_mut().len(), 1);
+
+        let mut dst = [std::io::IoSlice::new(&[]); 2];
+        assert_eq!(c.bytes_vectored(&mut dst[..]), 2);
+
+        assert_eq!(dst[0].len(), 2);
+        assert_eq!(dst[1].len(), 0);
+
+        let b1: &mut [u8] = &mut [];
+        let b2: &mut [u8] = &mut [];
+        let mut dst_mut = [bytes_rs::buf::IoSliceMut::from(b1), bytes_rs::buf::IoSliceMut::from(b2)];
+
+        assert_eq!(c.bytes_vectored_mut(&mut dst_mut[..]), 2);
+
+        assert!(c.has_remaining());
+        assert!(c.has_remaining_mut());
+    }
+
+    #[cfg(feature = "bytes")]
+    #[test]
+    fn bytes_buf_remaining() {
+        use bytes_rs::{Buf, BufMut};
+
+        let mut c = CircBuf::with_capacity(4).unwrap();
+
+        assert_eq!(c.remaining(), 0);
+        assert_eq!(c.remaining_mut(), 3);
+        assert!(!c.has_remaining());
+        assert!(c.has_remaining_mut());
+
+        unsafe { c.advance_mut(3); }
+
+        assert_eq!(c.remaining(), 3);
+        assert_eq!(c.remaining_mut(), 0);
+        assert!(c.has_remaining());
+        assert!(!c.has_remaining_mut());
+
+        c.advance(2);
+
+        assert_eq!(c.remaining(), 1);
+        assert_eq!(c.remaining_mut(), 2);
+        assert!(c.has_remaining());
+        assert!(c.has_remaining_mut());
+
+        c.advance(1);
+
+        assert_eq!(c.remaining(), 0);
+        assert_eq!(c.remaining_mut(), 3);
+        assert!(!c.has_remaining());
+        assert!(c.has_remaining_mut());
+    }
+
+    #[cfg(feature = "bytes")]
+    #[test]
+    fn bytes_bufmut_hello() {
+        use bytes_rs::{Buf, BufMut};
+
+        let mut c = CircBuf::with_capacity(16).unwrap();
+
+        unsafe {
+            c.bytes_mut()[0].as_mut_ptr().write(b'h');
+            c.bytes_mut()[1].as_mut_ptr().write(b'e');
+
+            c.advance_mut(2);
+
+            c.bytes_mut()[0].as_mut_ptr().write(b'l');
+            c.bytes_mut()[1].as_mut_ptr().write(b'l');
+            c.bytes_mut()[2].as_mut_ptr().write(b'o');
+
+            c.advance_mut(3);
+        }
+
+        assert_eq!(c.get_bytes()[0], b"hello");
     }
 
     #[cfg(feature = "nightly")]


### PR DESCRIPTION
This adds implementations of `Buf` and `BufMut` from the `bytes` crate to `CircBuf`. The implementations are behind an optional and default-off feature flag, to avoid adding an unnecessary dependency to people who do not care about these traits.

So far this is just the basic support. Let me know if you're interested in merging, and I will add some additional documentation and a test or two.

There is also one other change, which is to convert `get_bytes` and `get_bytes_upto_size` to take shared instead of exclusive references. This was necessary because `Buf`'s methods only take a `&self`. I don't know the motivation behind originally making `get_bytes` take a `&mut self`, will this be a problem?