### PR TITLE
flush bug behavior fix, now flush do nothing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -548,9 +548,8 @@ impl io::Write for CircBuf {
         Ok(num_to_write)
     }
 
-    /// Clear the buffer by setting the read and write pointers to 0.
+    /// Do nothing
     fn flush(&mut self) -> io::Result<()> {
-        self.clear();
         Ok(())
     }
 }


### PR DESCRIPTION
See doc https://doc.rust-lang.org/std/io/trait.Write.html#tymethod.flush:

> Flush this output stream, ensuring that all intermediately buffered contents reach their destination.

current behavior is the total opposite to what is expected. It should do nothing since all is already written in the buffer, like write impl of mutable slice https://doc.rust-lang.org/src/std/io/impls.rs.html#363