### PR TITLE
Benches update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,14 @@ documentation = "https://docs.rs/circbuf/"
 readme = "README.md"
 license = "MIT"
 keywords = ["buffer", "bytes", "circular", "ring"]
+edition = "2021"
 
 [features]
 nightly = []
-bytes = ["bytes_rs"]
 
 [dependencies]
-# Rename because a dependency can't have the same name as a feature.
-bytes_rs = { version = "0.5", optional = true, package = "bytes" }
+bytes = { version = "0.5", optional = true }
 
 [dev-dependencies]
 vecio = "0.1.0"
+tempfile = "3.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["buffer", "bytes", "circular", "ring"]
 edition = "2021"
 
 [features]
-nightly = []
 
 [dependencies]
 bytes = { version = "0.5", optional = true }

--- a/benches/read.rs
+++ b/benches/read.rs
@@ -1,0 +1,87 @@
+#![feature(can_vector)]
+#![feature(test)]
+extern crate test;
+
+use circbuf::CircBuf;
+use test::Bencher;
+
+use std::{
+    fs::File,
+    io::{copy, IoSliceMut, Read, Seek, Write},
+};
+
+const EXPECTED_N: usize = 12;
+
+fn prepare_file() -> File {
+    let mut file = tempfile::tempfile().unwrap();
+    assert_eq!(file.write(b"foo\nbar\nbaz\n").unwrap(), EXPECTED_N);
+    file
+}
+
+fn prepare_circbuf() -> CircBuf {
+    let mut c = CircBuf::with_capacity(16).unwrap();
+    c.advance_read(8);
+    c.advance_write(8);
+    c
+}
+
+#[bench]
+fn normal_read(b: &mut Bencher) {
+    let mut file = prepare_file();
+    let mut c = prepare_circbuf();
+
+    b.iter(|| {
+        file.rewind().unwrap();
+        let [mut a, mut b] = c.get_avail();
+        let n_a = file.read(&mut a).unwrap();
+        let n_b = file.read(&mut b).unwrap();
+        let n = n_a + n_b;
+        assert_eq!(n, EXPECTED_N);
+
+        c.advance_write(n);
+        c.advance_read(n);
+    })
+}
+
+#[bench]
+fn writer_read(b: &mut Bencher) {
+    let mut file = prepare_file();
+    let mut c = prepare_circbuf();
+
+    b.iter(|| {
+        file.rewind().unwrap();
+        let n = copy(&mut file, &mut c).unwrap() as usize;
+        assert_eq!(n, EXPECTED_N);
+        c.advance_read(n);
+    })
+}
+
+#[bench]
+#[ignore = "Test need OS with vectored read feature"]
+fn vector_read(b: &mut Bencher) {
+    let mut file = prepare_file();
+    assert!(file.is_read_vectored());
+    let mut c = prepare_circbuf();
+
+    b.iter(|| {
+        file.rewind().unwrap();
+        let mut bufs = {
+            let [a, b] = c.get_avail();
+            [IoSliceMut::new(a), IoSliceMut::new(b)]
+        };
+        let n = file.read_vectored(bufs.as_mut_slice()).unwrap();
+        assert_eq!(n, EXPECTED_N);
+        c.advance_write(n);
+        c.advance_read(n);
+    })
+}
+
+#[bench]
+// we call seek in iter in both benches above so lets get a base time for it
+fn seek_base(b: &mut Bencher) {
+    let mut file = prepare_file();
+
+    b.iter(|| {
+        file.rewind().unwrap();
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,13 +113,6 @@
 //!     }
 //! }
 //! ```
-#![cfg_attr(feature = "nightly", feature(test))]
-
-#[cfg(feature = "nightly")]
-extern crate test;
-
-#[cfg(feature = "bytes")]
-extern crate bytes_rs;
 
 use std::boxed::Box;
 use std::error;
@@ -555,7 +548,7 @@ impl io::Write for CircBuf {
 }
 
 #[cfg(feature = "bytes")]
-impl bytes_rs::Buf for CircBuf {
+impl bytes::Buf for CircBuf {
     fn remaining(&self) -> usize {
         self.len()
     }
@@ -591,7 +584,7 @@ impl bytes_rs::Buf for CircBuf {
 }
 
 #[cfg(feature = "bytes")]
-impl bytes_rs::BufMut for CircBuf {
+impl bytes::BufMut for CircBuf {
     fn remaining_mut(&self) -> usize {
         self.avail()
     }
@@ -615,16 +608,16 @@ impl bytes_rs::BufMut for CircBuf {
         }
     }
 
-    fn bytes_vectored_mut<'a>(&'a mut self, dst: &mut [bytes_rs::buf::IoSliceMut<'a>]) -> usize {
+    fn bytes_vectored_mut<'a>(&'a mut self, dst: &mut [bytes::buf::IoSliceMut<'a>]) -> usize {
         let [left, right] = self.get_avail();
         let mut count = 0;
         if let Some(slice) = dst.get_mut(0) {
             count += 1;
-            *slice = bytes_rs::buf::IoSliceMut::from(left);
+            *slice = bytes::buf::IoSliceMut::from(left);
         }
         if let Some(slice) = dst.get_mut(1) {
             count += 1;
-            *slice = bytes_rs::buf::IoSliceMut::from(right);
+            *slice = bytes::buf::IoSliceMut::from(right);
         }
         count
     }
@@ -632,17 +625,8 @@ impl bytes_rs::BufMut for CircBuf {
 
 #[cfg(test)]
 mod tests {
-    extern crate vecio;
-
-    #[cfg(unix)]
-    use self::vecio::Rawv;
     use super::{CircBuf, CircBufError, DEFAULT_CAPACITY};
-    use std::env;
-    use std::fs::OpenOptions;
-    use std::io::{Read, Seek, SeekFrom, Write};
-
-    #[cfg(feature = "nightly")]
-    use test::Bencher;
+    use std::io::{Read, Write};
 
     #[test]
     fn create_circbuf() {
@@ -923,19 +907,12 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn vecio() {
+        use vecio::Rawv;
+        use std::io::{Seek, SeekFrom};
+
         let mut c = CircBuf::with_capacity(16).unwrap();
 
-        let mut path = env::temp_dir();
-        path.push("circbuf-rs-test.txt");
-
-        let mut file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(path.to_str().unwrap())
-            .unwrap();
-
+        let mut file = tempfile::tempfile().unwrap();
         assert_eq!(file.write(b"foo\nbar\nbaz\n").unwrap(), 12);
         file.seek(SeekFrom::Current(-12)).unwrap();
 
@@ -959,7 +936,7 @@ mod tests {
     #[cfg(feature = "bytes")]
     #[test]
     fn bytes_buf_and_bufmut() {
-        use bytes_rs::{Buf, BufMut};
+        use bytes::{Buf, BufMut};
 
         let mut c = CircBuf::with_capacity(4).unwrap();
 
@@ -991,8 +968,8 @@ mod tests {
         let b1: &mut [u8] = &mut [];
         let b2: &mut [u8] = &mut [];
         let mut dst_mut = [
-            bytes_rs::buf::IoSliceMut::from(b1),
-            bytes_rs::buf::IoSliceMut::from(b2),
+            bytes::buf::IoSliceMut::from(b1),
+            bytes::buf::IoSliceMut::from(b2),
         ];
 
         assert_eq!(c.bytes_vectored_mut(&mut dst_mut[..]), 2);
@@ -1004,7 +981,7 @@ mod tests {
     #[cfg(feature = "bytes")]
     #[test]
     fn bytes_buf_remaining() {
-        use bytes_rs::{Buf, BufMut};
+        use bytes::{Buf, BufMut};
 
         let mut c = CircBuf::with_capacity(4).unwrap();
 
@@ -1040,7 +1017,7 @@ mod tests {
     #[cfg(feature = "bytes")]
     #[test]
     fn bytes_bufmut_hello() {
-        use bytes_rs::BufMut;
+        use bytes::BufMut;
 
         let mut c = CircBuf::with_capacity(16).unwrap();
 
@@ -1058,85 +1035,5 @@ mod tests {
         }
 
         assert_eq!(c.get_bytes()[0], b"hello");
-    }
-
-    #[cfg(feature = "nightly")]
-    #[bench]
-    pub fn normal_read(b: &mut Bencher) {
-        let mut c = CircBuf::with_capacity(16).unwrap();
-
-        let mut path = env::temp_dir();
-        path.push("circbuf-rs-test.txt");
-
-        let mut file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(path.to_str().unwrap())
-            .unwrap();
-
-        assert_eq!(file.write(b"foo\nbar\nbaz\n").unwrap(), 12);
-        file.seek(SeekFrom::Current(-12)).unwrap();
-
-        c.advance_read(8);
-        c.advance_write(8);
-        let mut bufs = c.get_avail();
-
-        b.iter(|| {
-            file.read(&mut bufs[0]).unwrap();
-            file.read(&mut bufs[1]).unwrap();
-            file.seek(SeekFrom::Current(-12)).unwrap();
-        })
-    }
-
-    #[cfg(feature = "nightly")]
-    #[cfg(unix)]
-    #[bench]
-    pub fn vector_read(b: &mut Bencher) {
-        let mut c = CircBuf::with_capacity(16).unwrap();
-
-        let mut path = env::temp_dir();
-        path.push("circbuf-rs-test.txt");
-
-        let mut file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(path.to_str().unwrap())
-            .unwrap();
-
-        assert_eq!(file.write(b"foo\nbar\nbaz\n").unwrap(), 12);
-        file.seek(SeekFrom::Current(-12)).unwrap();
-
-        c.advance_read(8);
-        c.advance_write(8);
-        let mut bufs = c.get_avail();
-
-        b.iter(|| {
-            file.readv(&mut bufs).unwrap();
-            file.seek(SeekFrom::Current(-12)).unwrap();
-        })
-    }
-
-    #[cfg(feature = "nightly")]
-    #[bench]
-    // we call seek in iter in both benches above so lets get a base time for it
-    pub fn seek_base(b: &mut Bencher) {
-        let mut path = env::temp_dir();
-        path.push("circbuf-rs-test.txt");
-
-        let mut file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(path.to_str().unwrap())
-            .unwrap();
-
-        b.iter(|| {
-            file.seek(SeekFrom::Current(1)).unwrap();
-        })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -907,8 +907,8 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn vecio() {
-        use vecio::Rawv;
         use std::io::{Seek, SeekFrom};
+        use vecio::Rawv;
 
         let mut c = CircBuf::with_capacity(16).unwrap();
 


### PR DESCRIPTION
- move benches into benches directory
- remove nightly feature only require for run bench, `cargo +nightly bench` or `rustup override set nightly`
- edition 2021
- add a bench for writer
- use `read_vectored` from std
- use `tempfile` to handle temporary file