### PR TITLE
Remove continue_on_error option for unstable jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -127,15 +127,12 @@ jobs:
             components: rustfmt, clippy
         
       - name: Build debug
-        continue-on-error: true
         run: cargo build --verbose
         
       - name: Build release
-        continue-on-error: true
         run: cargo build --release --verbose
   
       - uses: actions/upload-artifact@master
-        continue-on-error: true
         with:
           name: nightly-cargo-artefacts
           path: target
@@ -152,15 +149,12 @@ jobs:
             components: rustfmt, clippy
         
       - name: Build debug
-        continue-on-error: true
         run: cargo build --verbose
         
       - name: Build release
-        continue-on-error: true
         run: cargo build --release --verbose
   
       - uses: actions/upload-artifact@master
-        continue-on-error: true
         with:
           name: nightly-cargo-artefacts
           path: target
@@ -193,7 +187,6 @@ jobs:
   nightly-tests:
     runs-on: ubuntu-latest
     needs: ['nightly-build']
-    if: success()
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -219,7 +212,6 @@ jobs:
   beta-tests:
     runs-on: ubuntu-latest
     needs: ['beta-build']
-    if: success()
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -272,17 +264,14 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     needs: ["stable-tests"]
-    if: success()
     steps:          
       - name: Run cargo-tarpaulin in release
-        continue-on-error: true
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: '0.15.0'
           args: "--release --all-features -- --test-threads 1"
 
       - name: Upload to codecov.io
-        continue-on-error: true
         uses: codecov/codecov-action@v1.0.2
         with:
           token: ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -264,7 +264,10 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     needs: ["stable-tests"]
-    steps:          
+    steps:       
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - name: Run cargo-tarpaulin in release
         uses: actions-rs/tarpaulin@v0.1
         with:


### PR DESCRIPTION
Hello!

I've finally decided to remove the option continue_on_error for each unstable job that is allowed to fail. 
Builds and tests for nightly and beta version of rust are present to prevent breaking changes, these jobs should print a warning status when they fail but without breaking the workflow processes.

That's the same story for the coverage because of tarpaulin which is unstable.
It would be great to be able to declare a job allowed to fail, this is a wanted feature which does not exist for now.
See https://github.com/actions/runner/issues/2347

The trick is to use the if statement and the continue_on_error option to continue the workflow. It's not really acceptable because GitHub shows you a green status on the job and you have to see the output how each step to see the errors. 

I don't have a better solution, so I think we should remove these hacks from the workflow for now.